### PR TITLE
Only stop the app if the PR was updated

### DIFF
--- a/lib/simple_review_app/pull_request.rb
+++ b/lib/simple_review_app/pull_request.rb
@@ -12,15 +12,6 @@ class SimpleReviewApp
     attr_accessor :content, :full_repository_name
     attr_writer :logger
 
-    def update(directory)
-      if changed?(directory)
-        logger.info('Pull request changed, updating...')
-        fetch_and_reset(directory)
-      else
-        logger.info('Pull request did not change, continue...')
-      end
-    end
-
     def clone(directory)
       FileUtils.mkdir_p(directory) unless File.exist?(directory)
       Dir.chdir(directory) do
@@ -40,8 +31,6 @@ class SimpleReviewApp
       content.head.ref
     end
 
-    private
-
     def fetch_and_reset(directory)
       Dir.chdir(File.join(directory, project_name)) do
         capture2e_with_logs('git fetch --all')
@@ -53,6 +42,8 @@ class SimpleReviewApp
     def changed?(directory)
       head_sha != cloned_sha(directory)
     end
+
+    private
 
     def project_name
       content.head.repo.name

--- a/lib/simple_review_app/review_app.rb
+++ b/lib/simple_review_app/review_app.rb
@@ -66,10 +66,14 @@ class SimpleReviewApp
     end
 
     def update
-      pull_request.update(directory)
-
+      if pull_request.changed?(directory)
+        logger.info('Pull request changed, updating...')
+        pull_request.fetch_and_reset(directory)
+        stop_app
+      else
+        logger.info('Pull request did not change, continue...')
+      end
       provision
-      stop_app
       start_app
     end
 

--- a/spec/pull_request_spec.rb
+++ b/spec/pull_request_spec.rb
@@ -53,7 +53,7 @@ describe SimpleReviewApp::PullRequest, vcr: true do
     end
   end
 
-  describe '#update' do
+  describe '#fetch_and_reset' do
     let(:testdir) { 'spec/tmp/pull_request_spec' }
     let(:project_dir) { File.join(testdir, 'open-build-service') }
 
@@ -70,14 +70,7 @@ describe SimpleReviewApp::PullRequest, vcr: true do
       expect(subject).to receive(:capture2e_with_logs).with('git fetch --all')
       expect(subject).to receive(:capture2e_with_logs).with('git reset origin/bar --hard')
       allow(subject).to receive(:cloned_sha).and_return('different')
-      subject.update(testdir)
-    end
-
-    it 'does not update the pull request directory' do
-      expect(subject).not_to receive(:capture2e_with_logs).with('git fetch --all')
-      expect(subject).not_to receive(:capture2e_with_logs).with('git reset origin/bar --hard')
-      allow(subject).to receive(:cloned_sha).and_return(subject.content.head.sha)
-      subject.update(testdir)
+      subject.fetch_and_reset(testdir)
     end
   end
 end


### PR DESCRIPTION
No need to restart the app if nothing changed as this is rather destructive and expensive.

Also move the PullRequest.update logic into ReviewApp to make it more explicit what happens.