### PR TITLE
Use dependabot to keep github actions up to date

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,9 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "Dependabot - GitHub Actions"


### PR DESCRIPTION
It is easy to forget to keep our github actions up to date, like now where node.js 12 actions are going to be deprecated. Let Dependabot take care of this.